### PR TITLE
add prime mover regression solver

### DIFF
--- a/econ_dispatch/component_models/boiler.py
+++ b/econ_dispatch/component_models/boiler.py
@@ -150,9 +150,7 @@ class Component(ComponentBase):
             _log.debug("Training data does not meet standards: {}".format(err))
             inputs, outputs = utils.get_default_curve("boiler", self.capacity, 0.9)
 
-        a, b, xmin, xmax = utils.piecewise_linear(inputs, outputs, self.capacity,
-                                                  curve_func=lambda x, p0, p1, p2: p0 + p1*x + p2*x**2)
-                                                  # curve_func=lambda x, p0, p1, p2, p3: p0*x/(p1+p2*x+p3*x**2))
+        a, b, xmin, xmax = utils.piecewise_linear(inputs, outputs, self.capacity, curve_type='prime_mover')
 
         self.parameters = {
             "fundata": {

--- a/econ_dispatch/component_models/fuel_cell.py
+++ b/econ_dispatch/component_models/fuel_cell.py
@@ -190,9 +190,7 @@ class Component(ComponentBase):
             inputs, outputs = utils.get_default_curve("micro_turbine_generator", self.capacity, 0.35,
                                                         timestamps=timestamps)
 
-        a, b, xmin, xmax = utils.piecewise_linear(inputs, outputs, self.capacity,
-                                                  curve_func=lambda x, p0, p1, p2: p0 + p1*x + p2*x**2)
-                                                  # curve_func=lambda x, p0, p1, p2, p3: p0*x/(p1+p2*x+p3*x**2))
+        a, b, xmin, xmax = utils.piecewise_linear(inputs, outputs, self.capacity,curve_type='prime_mover')
 
         self.parameters = {
             "fundata": {

--- a/econ_dispatch/component_models/micro_turbine_generator.py
+++ b/econ_dispatch/component_models/micro_turbine_generator.py
@@ -201,9 +201,7 @@ class Component(ComponentBase):
             inputs, outputs = utils.get_default_curve("micro_turbine_generator", self.capacity, 0.35,
                                                         timestamps=timestamps)
 
-        # a, b, xmin, xmax = utils.piecewise_linear(inputs, outputs, self.capacity,
-        #                                           curve_func=lambda x, p0, p1, p2, p3: p0*x/(p1+p2*x+p3*x**2))
-        a, b, xmin, xmax = utils.piecewise_linear(inputs, outputs, self.capacity)
+        a, b, xmin, xmax = utils.piecewise_linear(inputs, outputs, self.capacity, curve_type = 'prime_mover')
 
         self.parameters = {
             "fundata": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ numpy
 pandas
 coolprop
 pulp
-scipy
+cvxopt


### PR DESCRIPTION
Requires cvxopt; solves quadratic programming problem to guard against singularities in prime mover regressions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/econ-dispatch/109)
<!-- Reviewable:end -->
